### PR TITLE
Mejorando visibilidad de README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,26 +40,51 @@ Si todo sale bien , el archivo __demo-factura-firmada.xml__ debería estar en do
 ## Corriendo con lenguajes ejemplo
 
 ### PHP:
-`<?php 
-   shell_exec("Java -jar ../ruta_personalizada/compilado/firmar-xades.jar ../ruta_personalizada/cert.p12 9865 ../ruta_personalizada/ demo-factura.xml ../ruta_personalizada/ demo-factura-firmada.xml");`
+```
+  <?php 
+   shell_exec("Java -jar ../ruta_personalizada/compilado/firmar-xades.jar ../ruta_personalizada/cert.p12 9865 ../ruta_personalizada/ demo-factura.xml ../ruta_personalizada/ demo-factura-firmada.xml");
+```
 
 ### Python:
-`import subprocess
- subprocess.call(['java', '-jar', '../ruta_personalizada/compilado/firmar-xades.jar' , ‘../ruta_personalizada/cert.p12’ , ‘9856’ , ‘../ruta_personalizada/ demo-factura.xml’, ‘../ruta_personalizada/ demo-factura-firmada.xml’])`
+```
+import subprocess
+subprocess.call([
+  'java',
+  '-jar',
+  '../ruta_personalizada/compilado/firmar-xades.jar',
+  ‘../ruta_personalizada/cert.p12’,
+  ‘9856’,
+  ‘../ruta_personalizada/demo-factura.xml’,
+  ‘../ruta_personalizada/demo-factura-firmada.xml’
+])
+```
 
 ### Ruby:
-`IO.popen( [ 'java', '-jar', '../ruta_personalizada/compilado/firmar-xades.jar,"#{ ../ruta_personalizada/cert.p12}", "#{9856}", “#{../ruta_personalizada/ demo-factura.xml}” ,”#{ demo-factura.xml ../ruta_personalizada/ demo-factura-firmada.xml}” , {SDTERR=>STDOUT} ]`
+```
+IO.popen([
+  'java',
+  '-jar',
+  '../ruta_personalizada/compilado/firmar-xades.jar,
+  "#{ ../ruta_personalizada/cert.p12}",
+  "#{9856}",
+  “#{../ruta_personalizada/demo-factura.xml}”,
+  ”#{../ruta_personalizada/demo-factura-firmada.xml}”,
+  {SDTERR=>STDOUT} 
+])
+```
 
 ### Node.JS:
-`var exec = require('child_process').exec, child;
-child = exec('java -jar ../ruta_personalizada/compilado/firmar-xades.jar ../ruta_personalizada/cert.p12 9865 ../ruta_personalizada/ demo-factura.xml ../ruta_personalizada/ demo-factura-firmada.xml',
+```
+var exec = require('child_process').exec, child;
+child = exec('java -jar ../ruta_personalizada/compilado/firmar-xades.jar ../ruta_personalizada/cert.p12 9865 ../ruta_personalizada/demo-factura.xml ../ruta_personalizada/demo-factura-firmada.xml',
   function (error, stdout, stderr){
     console.log('stdout: ' + stdout);
     console.log('stderr: ' + stderr);
     if(error !== null){
       console.log('exec error: ' + error);
     }
-});`
+});
+```
 
 ### __PD: Si desean mejorar esta documentación será bienvenido.__
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ Si todo sale bien , el archivo __demo-factura-firmada.xml__ debería estar en do
 ## Corriendo con lenguajes ejemplo
 
 ### PHP:
-```
+```php
   <?php 
    shell_exec("Java -jar ../ruta_personalizada/compilado/firmar-xades.jar ../ruta_personalizada/cert.p12 9865 ../ruta_personalizada/ demo-factura.xml ../ruta_personalizada/ demo-factura-firmada.xml");
 ```
 
 ### Python:
-```
+```python
 import subprocess
 subprocess.call([
   'java',
@@ -60,7 +60,7 @@ subprocess.call([
 ```
 
 ### Ruby:
-```
+```ruby
 IO.popen([
   'java',
   '-jar',
@@ -74,7 +74,7 @@ IO.popen([
 ```
 
 ### Node.JS:
-```
+```js
 var exec = require('child_process').exec, child;
 child = exec('java -jar ../ruta_personalizada/compilado/firmar-xades.jar ../ruta_personalizada/cert.p12 9865 ../ruta_personalizada/demo-factura.xml ../ruta_personalizada/demo-factura-firmada.xml',
   function (error, stdout, stderr){


### PR DESCRIPTION
Cambiando manera de desplegar los codigos de ejemplo, agregando ')' faltante al ejemplo de Ruby